### PR TITLE
feat: add _schema.yml for configuration validation and IDE support

### DIFF
--- a/_extensions/spotlight/_schema.yml
+++ b/_extensions/spotlight/_schema.yml
@@ -22,8 +22,9 @@ options:
     default: true
     description: "Whether to toggle the spotlight on and off by holding down the mouse button."
   spotlightOnKeyPressAndHold:
+    type: [boolean, number]
     default: false
-    description: "Whether to activate the spotlight on key press and hold. Set to false to disable, or use a key code number to bind to a specific key. Accepts boolean or number."
+    description: "Whether to activate the spotlight on key press and hold. Set to false to disable, or use a key code number to bind to a specific key."
   spotlightCursor:
     type: string
     default: "none"
@@ -41,8 +42,9 @@ options:
     default: true
     description: "Whether to disable text selection in presentation mode."
   fadeInAndOut:
+    type: [number, boolean]
     default: 100
-    description: "Transition duration in milliseconds for spotlight fade effects. Set to 0 or false to disable. Accepts number or boolean."
+    description: "Transition duration in milliseconds for spotlight fade effects. Set to 0 or false to disable."
   useAsPointer:
     type: boolean
     default: false

--- a/_extensions/spotlight/_schema.yml
+++ b/_extensions/spotlight/_schema.yml
@@ -23,8 +23,7 @@ options:
     description: "Whether to toggle the spotlight on and off by holding down the mouse button."
   spotlightOnKeyPressAndHold:
     type: number
-    default: false
-    description: "Key code to press and hold to activate the spotlight. Set to false to disable."
+    description: "Key code to press and hold to activate the spotlight. Omit or set to false to disable."
   spotlightCursor:
     type: string
     default: "none"

--- a/_extensions/spotlight/_schema.yml
+++ b/_extensions/spotlight/_schema.yml
@@ -1,0 +1,57 @@
+# _schema.yml for "spotlight" revealjs-plugin extension
+# Describes plugin options for IDE tooling and runtime validation.
+
+# Extension-level metadata options.
+# Configured in _quarto.yml, _metadata.yml, or document front matter under:
+#   revealjs-plugins:
+#     - spotlight
+# With configuration under:
+#   spotlight:
+#     size: 60
+options:
+  size:
+    type: number
+    default: 60
+    description: "Radius of the spotlight circle in pixels."
+  lockPointerInsideCanvas:
+    type: boolean
+    default: false
+    description: "Whether to lock the mouse pointer inside the presentation canvas using the Pointer Lock API."
+  toggleSpotlightOnMouseDown:
+    type: boolean
+    default: true
+    description: "Whether to toggle the spotlight on and off by holding down the mouse button."
+  spotlightOnKeyPressAndHold:
+    type: number
+    default: false
+    description: "Key code to press and hold to activate the spotlight. Set to false to disable."
+  spotlightCursor:
+    type: string
+    default: "none"
+    description: "CSS cursor style when the spotlight is active (e.g., 'crosshair', 'none')."
+  presentingCursor:
+    type: string
+    default: "none"
+    description: "CSS cursor style when in presentation mode with the spotlight off (e.g., 'default', 'none')."
+  initialPresentationMode:
+    type: boolean
+    default: true
+    description: "Whether to start in presentation mode. Defaults to true when toggleSpotlightOnMouseDown is enabled."
+  disablingUserSelect:
+    type: boolean
+    default: true
+    description: "Whether to disable text selection in presentation mode."
+  fadeInAndOut:
+    type: number
+    default: 100
+    description: "Transition duration in milliseconds for spotlight fade effects. Set to 0 or false to disable."
+  useAsPointer:
+    type: boolean
+    default: false
+    description: "Whether to use the spotlight as a coloured pointer instead of a spotlight circle."
+  pointerColor:
+    type: string
+    default: "red"
+    description: "Colour of the pointer when useAsPointer is enabled."
+    completion:
+      type: color

--- a/_extensions/spotlight/_schema.yml
+++ b/_extensions/spotlight/_schema.yml
@@ -22,9 +22,8 @@ options:
     default: true
     description: "Whether to toggle the spotlight on and off by holding down the mouse button."
   spotlightOnKeyPressAndHold:
-    type: boolean
     default: false
-    description: "Whether to activate the spotlight on key press and hold. Set to false to disable, or use a key code number to bind to a specific key."
+    description: "Whether to activate the spotlight on key press and hold. Set to false to disable, or use a key code number to bind to a specific key. Accepts boolean or number."
   spotlightCursor:
     type: string
     default: "none"
@@ -42,9 +41,8 @@ options:
     default: true
     description: "Whether to disable text selection in presentation mode."
   fadeInAndOut:
-    type: number
     default: 100
-    description: "Transition duration in milliseconds for spotlight fade effects. Set to 0 or false to disable."
+    description: "Transition duration in milliseconds for spotlight fade effects. Set to 0 or false to disable. Accepts number or boolean."
   useAsPointer:
     type: boolean
     default: false

--- a/_extensions/spotlight/_schema.yml
+++ b/_extensions/spotlight/_schema.yml
@@ -22,8 +22,9 @@ options:
     default: true
     description: "Whether to toggle the spotlight on and off by holding down the mouse button."
   spotlightOnKeyPressAndHold:
-    type: number
-    description: "Key code to press and hold to activate the spotlight. Omit or set to false to disable."
+    type: boolean
+    default: false
+    description: "Whether to activate the spotlight on key press and hold. Set to false to disable, or use a key code number to bind to a specific key."
   spotlightCursor:
     type: string
     default: "none"


### PR DESCRIPTION
## Summary

- Add `_extensions/spotlight/_schema.yml` describing all Reveal.js plugin options (`size`, `lockPointerInsideCanvas`, `toggleSpotlightOnMouseDown`, `spotlightOnKeyPressAndHold`, `spotlightCursor`, `presentingCursor`, `initialPresentationMode`, `disablingUserSelect`, `fadeInAndOut`, `useAsPointer`, `pointerColor`) for the `spotlight` extension.