### PR TITLE
feat: add extension-provided code snippets

### DIFF
--- a/_extensions/spotlight/_snippets.json
+++ b/_extensions/spotlight/_snippets.json
@@ -1,6 +1,6 @@
 {
 	"Spotlight config": {
-		"prefix": "spotlight-config",
+		"prefix": "meta",
 		"body": [
 			"revealjs-plugins:",
 			"  - spotlight",

--- a/_extensions/spotlight/_snippets.json
+++ b/_extensions/spotlight/_snippets.json
@@ -1,0 +1,13 @@
+{
+	"Spotlight config": {
+		"prefix": "spotlight-config",
+		"body": [
+			"revealjs-plugins:",
+			"  - spotlight",
+			"spotlight:",
+			"  size: ${1:60}",
+			"  toggleSpotlightOnMouseDown: ${2:true}"
+		],
+		"description": "Configure the spotlight Reveal.js plugin"
+	}
+}


### PR DESCRIPTION
## Summary

- Add `_snippets.json` file providing VS Code code snippets for Quarto Wizard IntelliSense.
- Related: mcanouil/quarto-wizard#279

## Test plan

- [ ] Verify `_snippets.json` is valid JSON.
- [ ] Install extension in a Quarto project with Quarto Wizard and verify snippets appear in IntelliSense.